### PR TITLE
fix(sidebar): guard missing tenantSettings.Common.AddOns (on-prem /home 500)

### DIFF
--- a/src/routes/users/[userId]/+layout.server.ts
+++ b/src/routes/users/[userId]/+layout.server.ts
@@ -17,6 +17,14 @@ export const load: LayoutServerLoad = async (event) => {
 
     const tenantSettings = await getTenantSettings(sessionId, session.tenantId);
 
+    // On-prem reancare's tenant-settings schema omits Common.AddOns (a newer portal
+    // feature). Default it so the sidebar menu builder's tenantSettings.Common.AddOns.*
+    // checks don't throw (the related add-on menus simply stay hidden).
+    const _ts = tenantSettings?.Data?.TenantSettings;
+    if (_ts?.Common && !_ts.Common.AddOns) {
+        _ts.Common.AddOns = {};
+    }
+
 	const sessionUser = {
         sessionId : session.sessionId,
         tenantId  : session.tenantId,


### PR DESCRIPTION
Post-login /home 500'd on on-prem: the sidebar builder reads tenantSettings.Common.AddOns.<flag> for 11 add-on menus, but on-prem reancare's tenant-settings omits Common.AddOns. This defaults it to {} so those menus hide instead of crashing. File: src/routes/users/[userId]/+layout.server.ts. Validated on on-prem dev (image develop_7273615, amd64). Not for AWS merge.